### PR TITLE
using colorama when under windows system

### DIFF
--- a/httpstat.py
+++ b/httpstat.py
@@ -15,6 +15,9 @@ import logging
 import tempfile
 import subprocess
 
+if os.name == 'nt':
+    from colorama import init
+    init()
 
 __version__ = '1.2.1'
 


### PR DESCRIPTION
This script work fine under my linux server, but color highlight is not working under window system, If you add colorama library, the color display will be fine.

But still need to modify setup.py by the way.