### PR TITLE
/ 1000 as some versions of curl return time in μs, not s

### DIFF
--- a/httpstat.py
+++ b/httpstat.py
@@ -249,7 +249,10 @@ def main():
     # convert time_ metrics from seconds to milliseconds
     for k in d:
         if k.startswith('time_'):
-            d[k] = int(d[k] * 1000)
+            if type(d[k]) == int:
+                d[k] = int(d[k] / 1000)
+            else:
+                d[k] = int(d[k] * 1000)
 
     # calculate ranges
     d.update(

--- a/httpstat.py
+++ b/httpstat.py
@@ -249,10 +249,19 @@ def main():
     # convert time_ metrics from seconds to milliseconds
     for k in d:
         if k.startswith('time_'):
-            if type(d[k]) == int:
-                d[k] = int(d[k] / 1000)
+            v = d[k]
+            # Convert time_ values to milliseconds in int
+            if isinstance(v, float):
+                # Before 7.61.0, time values are represented as seconds in float
+                d[k] = int(v * 1000)
+            elif isinstance(v, int):
+                # Starting from 7.61.0, libcurl uses microsecond in int
+                # to return time values, references:
+                # https://daniel.haxx.se/blog/2018/07/11/curl-7-61-0/
+                # https://curl.se/bug/?i=2495
+                d[k] = int(v / 1000)
             else:
-                d[k] = int(d[k] * 1000)
+                raise TypeError('{} value type is invalid: {}'.format(k, type(v)))
 
     # calculate ranges
     d.update(


### PR DESCRIPTION
My curl version is 7.74.0
curl 7.74.0 (x86_64-pc-win32) libcurl/7.74.0 OpenSSL/1.1.1i (Schannel) zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 WinIDN libssh2/1.9.0 nghttp2/1.42.0
Release-Date: 2020-12-09
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile MultiSSL NTLM SPNEGO SSL SSPI TLS-SRP Unicode UnixSockets alt-svc brotli libz zstd
![image](https://user-images.githubusercontent.com/7630767/102964539-e5b74880-4526-11eb-8a82-e5d71bb2102d.png)
